### PR TITLE
 Fix Windows console encoding issues in visualization

### DIFF
--- a/src/igniscad/visualization.py
+++ b/src/igniscad/visualization.py
@@ -25,13 +25,12 @@ def _show_yacv_model(model: Model, force: bool) -> bool:
     yacv_show(target_obj, names=[model.name])
 
     url = "http://localhost:32323"
-    print(f"Sent to YACV (open in your browser): {url}")
+    print(f"Sent to YACV (Check your browser, at {url})")
 
-    opened = webbrowser.open(url)
-    if not opened and not force:
+    if not (webbrowser.open(url) or force):
         return False  # Fallback
-    if not opened and force:
-        get_logger(__name__).warning("Browser unavailable (try using fallback mode)")
+    else:
+        get_logger(__name__).error("Browser unavailable.(try using fallback mode)")
 
     input("Press Enter to exit...")
     return True
@@ -49,7 +48,7 @@ def _export_stl_file(model: Model) -> None:
     bd.export_stl(model.part, filename)
     abs_path = os.path.abspath(filename)
     print(f"Saved: {abs_path}")
-    print("You can open this file with 3D viewer applications.")
+    print("You can open this file with 3D Viewer Applications.")
 
     from contextlib import suppress
     with suppress(Exception):

--- a/src/igniscad/visualization.py
+++ b/src/igniscad/visualization.py
@@ -25,14 +25,15 @@ def _show_yacv_model(model: Model, force: bool) -> bool:
     yacv_show(target_obj, names=[model.name])
 
     url = "http://localhost:32323"
-    print(f"✅ Sent to YACV (Check your browser, at {url})")
+    print(f"Sent to YACV (open in your browser): {url}")
 
-    if not (webbrowser.open(url) or force):
+    opened = webbrowser.open(url)
+    if not opened and not force:
         return False  # Fallback
-    else:
-        get_logger(__name__).error("Browser unavailable.(try using fallback mode)")
+    if not opened and force:
+        get_logger(__name__).warning("Browser unavailable (try using fallback mode)")
 
-    input("✅ Press Enter to exit...")
+    input("Press Enter to exit...")
     return True
 
 
@@ -47,8 +48,8 @@ def _export_stl_file(model: Model) -> None:
     model.part = model.wrap_result(model.part) # Necessary: wrap everything into compound.
     bd.export_stl(model.part, filename)
     abs_path = os.path.abspath(filename)
-    print(f"💾 Saved: {abs_path}")
-    print("👉 You can open this file with 3D Viewer Applications.")
+    print(f"Saved: {abs_path}")
+    print("You can open this file with 3D viewer applications.")
 
     from contextlib import suppress
     with suppress(Exception):


### PR DESCRIPTION
Fixes UnicodeEncodeError on Windows consoles using GBK by removing emoji from visualization prints and improving browser-open fallback logic.

Repro:
- Run examples on Windows with default code page (GBK)
- visualization.py prints emoji (✅/💾/👉) causing UnicodeEncodeError

Changes:
- Replace emoji prints with ASCII
- Fix _show_yacv_model browser-open fallback logic and keep prompts ASCII
